### PR TITLE
Quanta emission change to 2 Quanta per minute

### DIFF
--- a/Change Quanta emission to 2/test
+++ b/Change Quanta emission to 2/test
@@ -1,0 +1,37 @@
+  QIP: 009  
+	Layer: Node
+	Title: Change Quanta emission to 2
+	Author: Ottslayer
+	Comments-Summary: 
+	Comments-URI: https://github.com/theQRL/qips/pull/21
+	Status: Open  
+	Type: emission
+	Created: 2019-11-9
+
+# Title
+
+Change Quanta emission to 2 per minute
+
+## Abstract
+
+emission is currently close to 6 Quanta per minute and will be exponentially reduced to 0 in aproximately 200 years. Reducing the emission to 2 Quanta per minute will reduce the availability of Quanta.
+
+
+## Motivation
+
+lower emission rate will most likely increase demand of Quanta, the price, and people who are willing to point their mining rigs to qrl which will enlarge the network.
+
+
+## Specification
+
+To be determined by team if accepted.
+
+
+## Backward compatibility
+
+Changing the emission is a hard fork upgrade? 
+
+
+## Implementation
+
+To be determined by team if accepted.


### PR DESCRIPTION
emission is currently close to 6 Quanta per minute and will be exponentially reduced to 0 in aproximately 200 years. Reducing the emission to 2 Quanta per minute will reduce the availability of Quanta.

lower emission rate will most likely increase demand of Quanta, the price, and people who are willing to point their mining rigs to qrl which will enlarge the network.